### PR TITLE
TripInfo from Pulsar properties to payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl</groupId>
     <artifactId>transitdata-common</artifactId>
-    <version>0.7.4</version>
+    <version>0.7.6</version>
     <packaging>jar</packaging>
     <name>Common utilities for Transitdata projects</name>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl</groupId>
     <artifactId>transitdata-common</artifactId>
-    <version>0.7.6</version>
+    <version>0.8.0</version>
     <packaging>jar</packaging>
     <name>Common utilities for Transitdata projects</name>
     <properties>

--- a/protos/pubtrans-tables.proto
+++ b/protos/pubtrans-tables.proto
@@ -34,7 +34,7 @@ message DOITripInfo {
     required string route_id = 3;
     required uint32 direction_id = 4;
     required string start_time = 5;
-    required int64 stop_id = 6;
+    required string stop_id = 6;
 }
 
 message ROIArrival {

--- a/protos/pubtrans-tables.proto
+++ b/protos/pubtrans-tables.proto
@@ -27,13 +27,27 @@ message Common {
     required int64 last_modified_utc_date_time_ms = 17;
 }
 
+message DOITripInfo {
+    // All fields in JORE-format
+    required int64 dvj_id = 1;
+    required string operating_day = 2;
+    required string route_id = 3;
+    required uint32 direction_id = 4;
+    required string start_time = 5;
+    required int64 stop_id = 6;
+}
+
 message ROIArrival {
-    required Common common = 1;
+    required int32 schema_version = 1 [default = 1]; // Remember to bump up the version when updating the scema!
+    required Common common = 2;
+    required DOITripInfo trip_info = 3;
 }
 
 message ROIDeparture {
-    required Common common = 1;
-    optional int64 has_destination_display_id = 2;
-    optional int64 has_destination_stop_area_gid = 3;
-    optional int64 has_service_requirement_id = 4;
+    required int32 schema_version = 1 [default = 1]; // Remember to bump up the version when updating the scema!
+    required Common common = 2;
+    required DOITripInfo trip_info = 3;
+    optional int64 has_destination_display_id = 4;
+    optional int64 has_destination_stop_area_gid = 5;
+    optional int64 has_service_requirement_id = 6;
 }

--- a/src/main/java/fi/hsl/common/transitdata/proto/PubtransTableProtos.java
+++ b/src/main/java/fi/hsl/common/transitdata/proto/PubtransTableProtos.java
@@ -2132,13 +2132,18 @@ public final class PubtransTableProtos {
         getStartTimeBytes();
 
     /**
-     * <code>required int64 stop_id = 6;</code>
+     * <code>required string stop_id = 6;</code>
      */
     boolean hasStopId();
     /**
-     * <code>required int64 stop_id = 6;</code>
+     * <code>required string stop_id = 6;</code>
      */
-    long getStopId();
+    java.lang.String getStopId();
+    /**
+     * <code>required string stop_id = 6;</code>
+     */
+    com.google.protobuf.ByteString
+        getStopIdBytes();
   }
   /**
    * Protobuf type {@code proto.DOITripInfo}
@@ -2158,7 +2163,7 @@ public final class PubtransTableProtos {
       routeId_ = "";
       directionId_ = 0;
       startTime_ = "";
-      stopId_ = 0L;
+      stopId_ = "";
     }
 
     @java.lang.Override
@@ -2213,9 +2218,10 @@ public final class PubtransTableProtos {
               startTime_ = bs;
               break;
             }
-            case 48: {
+            case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              stopId_ = input.readInt64();
+              stopId_ = bs;
               break;
             }
             default: {
@@ -2416,18 +2422,45 @@ public final class PubtransTableProtos {
     }
 
     public static final int STOP_ID_FIELD_NUMBER = 6;
-    private long stopId_;
+    private volatile java.lang.Object stopId_;
     /**
-     * <code>required int64 stop_id = 6;</code>
+     * <code>required string stop_id = 6;</code>
      */
     public boolean hasStopId() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
-     * <code>required int64 stop_id = 6;</code>
+     * <code>required string stop_id = 6;</code>
      */
-    public long getStopId() {
-      return stopId_;
+    public java.lang.String getStopId() {
+      java.lang.Object ref = stopId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          stopId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string stop_id = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getStopIdBytes() {
+      java.lang.Object ref = stopId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        stopId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2484,7 +2517,7 @@ public final class PubtransTableProtos {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, startTime_);
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeInt64(6, stopId_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, stopId_);
       }
       unknownFields.writeTo(output);
     }
@@ -2513,8 +2546,7 @@ public final class PubtransTableProtos {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, startTime_);
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(6, stopId_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, stopId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2559,8 +2591,8 @@ public final class PubtransTableProtos {
       }
       result = result && (hasStopId() == other.hasStopId());
       if (hasStopId()) {
-        result = result && (getStopId()
-            == other.getStopId());
+        result = result && getStopId()
+            .equals(other.getStopId());
       }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
@@ -2596,8 +2628,7 @@ public final class PubtransTableProtos {
       }
       if (hasStopId()) {
         hash = (37 * hash) + STOP_ID_FIELD_NUMBER;
-        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-            getStopId());
+        hash = (53 * hash) + getStopId().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2742,7 +2773,7 @@ public final class PubtransTableProtos {
         bitField0_ = (bitField0_ & ~0x00000008);
         startTime_ = "";
         bitField0_ = (bitField0_ & ~0x00000010);
-        stopId_ = 0L;
+        stopId_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
@@ -2867,7 +2898,9 @@ public final class PubtransTableProtos {
           onChanged();
         }
         if (other.hasStopId()) {
-          setStopId(other.getStopId());
+          bitField0_ |= 0x00000020;
+          stopId_ = other.stopId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3225,34 +3258,78 @@ public final class PubtransTableProtos {
         return this;
       }
 
-      private long stopId_ ;
+      private java.lang.Object stopId_ = "";
       /**
-       * <code>required int64 stop_id = 6;</code>
+       * <code>required string stop_id = 6;</code>
        */
       public boolean hasStopId() {
         return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
-       * <code>required int64 stop_id = 6;</code>
+       * <code>required string stop_id = 6;</code>
        */
-      public long getStopId() {
-        return stopId_;
+      public java.lang.String getStopId() {
+        java.lang.Object ref = stopId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            stopId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
       }
       /**
-       * <code>required int64 stop_id = 6;</code>
+       * <code>required string stop_id = 6;</code>
        */
-      public Builder setStopId(long value) {
-        bitField0_ |= 0x00000020;
+      public com.google.protobuf.ByteString
+          getStopIdBytes() {
+        java.lang.Object ref = stopId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          stopId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string stop_id = 6;</code>
+       */
+      public Builder setStopId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
         stopId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>required int64 stop_id = 6;</code>
+       * <code>required string stop_id = 6;</code>
        */
       public Builder clearStopId() {
         bitField0_ = (bitField0_ & ~0x00000020);
-        stopId_ = 0L;
+        stopId_ = getDefaultInstance().getStopId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string stop_id = 6;</code>
+       */
+      public Builder setStopIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        stopId_ = value;
         onChanged();
         return this;
       }
@@ -5560,7 +5637,7 @@ public final class PubtransTableProtos {
       "ified_utc_date_time_ms\030\021 \002(\003\"\201\001\n\013DOITrip" +
       "Info\022\016\n\006dvj_id\030\001 \002(\003\022\025\n\roperating_day\030\002 " +
       "\002(\t\022\020\n\010route_id\030\003 \002(\t\022\024\n\014direction_id\030\004 " +
-      "\002(\r\022\022\n\nstart_time\030\005 \002(\t\022\017\n\007stop_id\030\006 \002(\003" +
+      "\002(\r\022\022\n\nstart_time\030\005 \002(\t\022\017\n\007stop_id\030\006 \002(\t" +
       "\"m\n\nROIArrival\022\031\n\016schema_version\030\001 \002(\005:\001" +
       "1\022\035\n\006common\030\002 \002(\0132\r.proto.Common\022%\n\ttrip" +
       "_info\030\003 \002(\0132\022.proto.DOITripInfo\"\336\001\n\014ROID" +

--- a/src/main/java/fi/hsl/common/transitdata/proto/PubtransTableProtos.java
+++ b/src/main/java/fi/hsl/common/transitdata/proto/PubtransTableProtos.java
@@ -2059,22 +2059,1302 @@ public final class PubtransTableProtos {
 
   }
 
+  public interface DOITripInfoOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:proto.DOITripInfo)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * All fields in JORE-format
+     * </pre>
+     *
+     * <code>required int64 dvj_id = 1;</code>
+     */
+    boolean hasDvjId();
+    /**
+     * <pre>
+     * All fields in JORE-format
+     * </pre>
+     *
+     * <code>required int64 dvj_id = 1;</code>
+     */
+    long getDvjId();
+
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    boolean hasOperatingDay();
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    java.lang.String getOperatingDay();
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getOperatingDayBytes();
+
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    boolean hasRouteId();
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    java.lang.String getRouteId();
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getRouteIdBytes();
+
+    /**
+     * <code>required uint32 direction_id = 4;</code>
+     */
+    boolean hasDirectionId();
+    /**
+     * <code>required uint32 direction_id = 4;</code>
+     */
+    int getDirectionId();
+
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    boolean hasStartTime();
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    java.lang.String getStartTime();
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getStartTimeBytes();
+
+    /**
+     * <code>required int64 stop_id = 6;</code>
+     */
+    boolean hasStopId();
+    /**
+     * <code>required int64 stop_id = 6;</code>
+     */
+    long getStopId();
+  }
+  /**
+   * Protobuf type {@code proto.DOITripInfo}
+   */
+  public  static final class DOITripInfo extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:proto.DOITripInfo)
+      DOITripInfoOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use DOITripInfo.newBuilder() to construct.
+    private DOITripInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private DOITripInfo() {
+      dvjId_ = 0L;
+      operatingDay_ = "";
+      routeId_ = "";
+      directionId_ = 0;
+      startTime_ = "";
+      stopId_ = 0L;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DOITripInfo(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+              bitField0_ |= 0x00000001;
+              dvjId_ = input.readInt64();
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              operatingDay_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              routeId_ = bs;
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              directionId_ = input.readUInt32();
+              break;
+            }
+            case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              startTime_ = bs;
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              stopId_ = input.readInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return fi.hsl.common.transitdata.proto.PubtransTableProtos.internal_static_proto_DOITripInfo_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return fi.hsl.common.transitdata.proto.PubtransTableProtos.internal_static_proto_DOITripInfo_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.class, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int DVJ_ID_FIELD_NUMBER = 1;
+    private long dvjId_;
+    /**
+     * <pre>
+     * All fields in JORE-format
+     * </pre>
+     *
+     * <code>required int64 dvj_id = 1;</code>
+     */
+    public boolean hasDvjId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <pre>
+     * All fields in JORE-format
+     * </pre>
+     *
+     * <code>required int64 dvj_id = 1;</code>
+     */
+    public long getDvjId() {
+      return dvjId_;
+    }
+
+    public static final int OPERATING_DAY_FIELD_NUMBER = 2;
+    private volatile java.lang.Object operatingDay_;
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    public boolean hasOperatingDay() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    public java.lang.String getOperatingDay() {
+      java.lang.Object ref = operatingDay_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          operatingDay_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string operating_day = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getOperatingDayBytes() {
+      java.lang.Object ref = operatingDay_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        operatingDay_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ROUTE_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object routeId_;
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    public boolean hasRouteId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    public java.lang.String getRouteId() {
+      java.lang.Object ref = routeId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          routeId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string route_id = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRouteIdBytes() {
+      java.lang.Object ref = routeId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        routeId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int DIRECTION_ID_FIELD_NUMBER = 4;
+    private int directionId_;
+    /**
+     * <code>required uint32 direction_id = 4;</code>
+     */
+    public boolean hasDirectionId() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>required uint32 direction_id = 4;</code>
+     */
+    public int getDirectionId() {
+      return directionId_;
+    }
+
+    public static final int START_TIME_FIELD_NUMBER = 5;
+    private volatile java.lang.Object startTime_;
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    public boolean hasStartTime() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    public java.lang.String getStartTime() {
+      java.lang.Object ref = startTime_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          startTime_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string start_time = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getStartTimeBytes() {
+      java.lang.Object ref = startTime_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        startTime_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STOP_ID_FIELD_NUMBER = 6;
+    private long stopId_;
+    /**
+     * <code>required int64 stop_id = 6;</code>
+     */
+    public boolean hasStopId() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>required int64 stop_id = 6;</code>
+     */
+    public long getStopId() {
+      return stopId_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasDvjId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasOperatingDay()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasRouteId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasDirectionId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasStartTime()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasStopId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, dvjId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, operatingDay_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, routeId_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeUInt32(4, directionId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, startTime_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeInt64(6, stopId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, dvjId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, operatingDay_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, routeId_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(4, directionId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, startTime_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(6, stopId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo)) {
+        return super.equals(obj);
+      }
+      fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo other = (fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo) obj;
+
+      boolean result = true;
+      result = result && (hasDvjId() == other.hasDvjId());
+      if (hasDvjId()) {
+        result = result && (getDvjId()
+            == other.getDvjId());
+      }
+      result = result && (hasOperatingDay() == other.hasOperatingDay());
+      if (hasOperatingDay()) {
+        result = result && getOperatingDay()
+            .equals(other.getOperatingDay());
+      }
+      result = result && (hasRouteId() == other.hasRouteId());
+      if (hasRouteId()) {
+        result = result && getRouteId()
+            .equals(other.getRouteId());
+      }
+      result = result && (hasDirectionId() == other.hasDirectionId());
+      if (hasDirectionId()) {
+        result = result && (getDirectionId()
+            == other.getDirectionId());
+      }
+      result = result && (hasStartTime() == other.hasStartTime());
+      if (hasStartTime()) {
+        result = result && getStartTime()
+            .equals(other.getStartTime());
+      }
+      result = result && (hasStopId() == other.hasStopId());
+      if (hasStopId()) {
+        result = result && (getStopId()
+            == other.getStopId());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasDvjId()) {
+        hash = (37 * hash) + DVJ_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getDvjId());
+      }
+      if (hasOperatingDay()) {
+        hash = (37 * hash) + OPERATING_DAY_FIELD_NUMBER;
+        hash = (53 * hash) + getOperatingDay().hashCode();
+      }
+      if (hasRouteId()) {
+        hash = (37 * hash) + ROUTE_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRouteId().hashCode();
+      }
+      if (hasDirectionId()) {
+        hash = (37 * hash) + DIRECTION_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getDirectionId();
+      }
+      if (hasStartTime()) {
+        hash = (37 * hash) + START_TIME_FIELD_NUMBER;
+        hash = (53 * hash) + getStartTime().hashCode();
+      }
+      if (hasStopId()) {
+        hash = (37 * hash) + STOP_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getStopId());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code proto.DOITripInfo}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:proto.DOITripInfo)
+        fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return fi.hsl.common.transitdata.proto.PubtransTableProtos.internal_static_proto_DOITripInfo_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return fi.hsl.common.transitdata.proto.PubtransTableProtos.internal_static_proto_DOITripInfo_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.class, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder.class);
+      }
+
+      // Construct using fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        dvjId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        operatingDay_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        routeId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        directionId_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        startTime_ = "";
+        bitField0_ = (bitField0_ & ~0x00000010);
+        stopId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return fi.hsl.common.transitdata.proto.PubtransTableProtos.internal_static_proto_DOITripInfo_descriptor;
+      }
+
+      @java.lang.Override
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getDefaultInstanceForType() {
+        return fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo build() {
+        fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo buildPartial() {
+        fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo result = new fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.dvjId_ = dvjId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.operatingDay_ = operatingDay_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.routeId_ = routeId_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.directionId_ = directionId_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.startTime_ = startTime_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.stopId_ = stopId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo) {
+          return mergeFrom((fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo other) {
+        if (other == fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance()) return this;
+        if (other.hasDvjId()) {
+          setDvjId(other.getDvjId());
+        }
+        if (other.hasOperatingDay()) {
+          bitField0_ |= 0x00000002;
+          operatingDay_ = other.operatingDay_;
+          onChanged();
+        }
+        if (other.hasRouteId()) {
+          bitField0_ |= 0x00000004;
+          routeId_ = other.routeId_;
+          onChanged();
+        }
+        if (other.hasDirectionId()) {
+          setDirectionId(other.getDirectionId());
+        }
+        if (other.hasStartTime()) {
+          bitField0_ |= 0x00000010;
+          startTime_ = other.startTime_;
+          onChanged();
+        }
+        if (other.hasStopId()) {
+          setStopId(other.getStopId());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasDvjId()) {
+          return false;
+        }
+        if (!hasOperatingDay()) {
+          return false;
+        }
+        if (!hasRouteId()) {
+          return false;
+        }
+        if (!hasDirectionId()) {
+          return false;
+        }
+        if (!hasStartTime()) {
+          return false;
+        }
+        if (!hasStopId()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long dvjId_ ;
+      /**
+       * <pre>
+       * All fields in JORE-format
+       * </pre>
+       *
+       * <code>required int64 dvj_id = 1;</code>
+       */
+      public boolean hasDvjId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * All fields in JORE-format
+       * </pre>
+       *
+       * <code>required int64 dvj_id = 1;</code>
+       */
+      public long getDvjId() {
+        return dvjId_;
+      }
+      /**
+       * <pre>
+       * All fields in JORE-format
+       * </pre>
+       *
+       * <code>required int64 dvj_id = 1;</code>
+       */
+      public Builder setDvjId(long value) {
+        bitField0_ |= 0x00000001;
+        dvjId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * All fields in JORE-format
+       * </pre>
+       *
+       * <code>required int64 dvj_id = 1;</code>
+       */
+      public Builder clearDvjId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        dvjId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object operatingDay_ = "";
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public boolean hasOperatingDay() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public java.lang.String getOperatingDay() {
+        java.lang.Object ref = operatingDay_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            operatingDay_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getOperatingDayBytes() {
+        java.lang.Object ref = operatingDay_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          operatingDay_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public Builder setOperatingDay(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        operatingDay_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public Builder clearOperatingDay() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        operatingDay_ = getDefaultInstance().getOperatingDay();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string operating_day = 2;</code>
+       */
+      public Builder setOperatingDayBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        operatingDay_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object routeId_ = "";
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public boolean hasRouteId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public java.lang.String getRouteId() {
+        java.lang.Object ref = routeId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            routeId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRouteIdBytes() {
+        java.lang.Object ref = routeId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          routeId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public Builder setRouteId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        routeId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public Builder clearRouteId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        routeId_ = getDefaultInstance().getRouteId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string route_id = 3;</code>
+       */
+      public Builder setRouteIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        routeId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int directionId_ ;
+      /**
+       * <code>required uint32 direction_id = 4;</code>
+       */
+      public boolean hasDirectionId() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>required uint32 direction_id = 4;</code>
+       */
+      public int getDirectionId() {
+        return directionId_;
+      }
+      /**
+       * <code>required uint32 direction_id = 4;</code>
+       */
+      public Builder setDirectionId(int value) {
+        bitField0_ |= 0x00000008;
+        directionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required uint32 direction_id = 4;</code>
+       */
+      public Builder clearDirectionId() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        directionId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object startTime_ = "";
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public boolean hasStartTime() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public java.lang.String getStartTime() {
+        java.lang.Object ref = startTime_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            startTime_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getStartTimeBytes() {
+        java.lang.Object ref = startTime_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          startTime_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public Builder setStartTime(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        startTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public Builder clearStartTime() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        startTime_ = getDefaultInstance().getStartTime();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string start_time = 5;</code>
+       */
+      public Builder setStartTimeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        startTime_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long stopId_ ;
+      /**
+       * <code>required int64 stop_id = 6;</code>
+       */
+      public boolean hasStopId() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>required int64 stop_id = 6;</code>
+       */
+      public long getStopId() {
+        return stopId_;
+      }
+      /**
+       * <code>required int64 stop_id = 6;</code>
+       */
+      public Builder setStopId(long value) {
+        bitField0_ |= 0x00000020;
+        stopId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 stop_id = 6;</code>
+       */
+      public Builder clearStopId() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        stopId_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:proto.DOITripInfo)
+    }
+
+    // @@protoc_insertion_point(class_scope:proto.DOITripInfo)
+    private static final fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo();
+    }
+
+    public static fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<DOITripInfo>
+        PARSER = new com.google.protobuf.AbstractParser<DOITripInfo>() {
+      @java.lang.Override
+      public DOITripInfo parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new DOITripInfo(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<DOITripInfo> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DOITripInfo> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface ROIArrivalOrBuilder extends
       // @@protoc_insertion_point(interface_extends:proto.ROIArrival)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    boolean hasSchemaVersion();
+    /**
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    int getSchemaVersion();
+
+    /**
+     * <code>required .proto.Common common = 2;</code>
      */
     boolean hasCommon();
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon();
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder();
+
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    boolean hasTripInfo();
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo();
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder();
   }
   /**
    * Protobuf type {@code proto.ROIArrival}
@@ -2089,6 +3369,7 @@ public final class PubtransTableProtos {
       super(builder);
     }
     private ROIArrival() {
+      schemaVersion_ = 1;
     }
 
     @java.lang.Override
@@ -2115,9 +3396,14 @@ public final class PubtransTableProtos {
             case 0:
               done = true;
               break;
-            case 10: {
+            case 8: {
+              bitField0_ |= 0x00000001;
+              schemaVersion_ = input.readInt32();
+              break;
+            }
+            case 18: {
               fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = common_.toBuilder();
               }
               common_ = input.readMessage(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.PARSER, extensionRegistry);
@@ -2125,7 +3411,20 @@ public final class PubtransTableProtos {
                 subBuilder.mergeFrom(common_);
                 common_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00000001;
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            case 26: {
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                subBuilder = tripInfo_.toBuilder();
+              }
+              tripInfo_ = input.readMessage(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(tripInfo_);
+                tripInfo_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000004;
               break;
             }
             default: {
@@ -2161,25 +3460,69 @@ public final class PubtransTableProtos {
     }
 
     private int bitField0_;
-    public static final int COMMON_FIELD_NUMBER = 1;
-    private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_;
+    public static final int SCHEMA_VERSION_FIELD_NUMBER = 1;
+    private int schemaVersion_;
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
      */
-    public boolean hasCommon() {
+    public boolean hasSchemaVersion() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    public int getSchemaVersion() {
+      return schemaVersion_;
+    }
+
+    public static final int COMMON_FIELD_NUMBER = 2;
+    private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_;
+    /**
+     * <code>required .proto.Common common = 2;</code>
+     */
+    public boolean hasCommon() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required .proto.Common common = 2;</code>
      */
     public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon() {
       return common_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance() : common_;
     }
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     public fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder() {
       return common_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance() : common_;
+    }
+
+    public static final int TRIP_INFO_FIELD_NUMBER = 3;
+    private fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo tripInfo_;
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    public boolean hasTripInfo() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo() {
+      return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+    }
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder() {
+      return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2189,11 +3532,23 @@ public final class PubtransTableProtos {
       if (isInitialized == 1) return true;
       if (isInitialized == 0) return false;
 
+      if (!hasSchemaVersion()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
       if (!hasCommon()) {
         memoizedIsInitialized = 0;
         return false;
       }
+      if (!hasTripInfo()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
       if (!getCommon().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getTripInfo().isInitialized()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -2205,7 +3560,13 @@ public final class PubtransTableProtos {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeMessage(1, getCommon());
+        output.writeInt32(1, schemaVersion_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(2, getCommon());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeMessage(3, getTripInfo());
       }
       unknownFields.writeTo(output);
     }
@@ -2218,7 +3579,15 @@ public final class PubtransTableProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getCommon());
+          .computeInt32Size(1, schemaVersion_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getCommon());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, getTripInfo());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2236,10 +3605,20 @@ public final class PubtransTableProtos {
       fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIArrival other = (fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIArrival) obj;
 
       boolean result = true;
+      result = result && (hasSchemaVersion() == other.hasSchemaVersion());
+      if (hasSchemaVersion()) {
+        result = result && (getSchemaVersion()
+            == other.getSchemaVersion());
+      }
       result = result && (hasCommon() == other.hasCommon());
       if (hasCommon()) {
         result = result && getCommon()
             .equals(other.getCommon());
+      }
+      result = result && (hasTripInfo() == other.hasTripInfo());
+      if (hasTripInfo()) {
+        result = result && getTripInfo()
+            .equals(other.getTripInfo());
       }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
@@ -2252,9 +3631,17 @@ public final class PubtransTableProtos {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasSchemaVersion()) {
+        hash = (37 * hash) + SCHEMA_VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getSchemaVersion();
+      }
       if (hasCommon()) {
         hash = (37 * hash) + COMMON_FIELD_NUMBER;
         hash = (53 * hash) + getCommon().hashCode();
+      }
+      if (hasTripInfo()) {
+        hash = (37 * hash) + TRIP_INFO_FIELD_NUMBER;
+        hash = (53 * hash) + getTripInfo().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2385,17 +3772,26 @@ public final class PubtransTableProtos {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
           getCommonFieldBuilder();
+          getTripInfoFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        schemaVersion_ = 1;
+        bitField0_ = (bitField0_ & ~0x00000001);
         if (commonBuilder_ == null) {
           common_ = null;
         } else {
           commonBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000002);
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = null;
+        } else {
+          tripInfoBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -2427,10 +3823,22 @@ public final class PubtransTableProtos {
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
           to_bitField0_ |= 0x00000001;
         }
+        result.schemaVersion_ = schemaVersion_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
         if (commonBuilder_ == null) {
           result.common_ = common_;
         } else {
           result.common_ = commonBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        if (tripInfoBuilder_ == null) {
+          result.tripInfo_ = tripInfo_;
+        } else {
+          result.tripInfo_ = tripInfoBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -2481,8 +3889,14 @@ public final class PubtransTableProtos {
 
       public Builder mergeFrom(fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIArrival other) {
         if (other == fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIArrival.getDefaultInstance()) return this;
+        if (other.hasSchemaVersion()) {
+          setSchemaVersion(other.getSchemaVersion());
+        }
         if (other.hasCommon()) {
           mergeCommon(other.getCommon());
+        }
+        if (other.hasTripInfo()) {
+          mergeTripInfo(other.getTripInfo());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -2491,10 +3905,19 @@ public final class PubtransTableProtos {
 
       @java.lang.Override
       public final boolean isInitialized() {
+        if (!hasSchemaVersion()) {
+          return false;
+        }
         if (!hasCommon()) {
           return false;
         }
+        if (!hasTripInfo()) {
+          return false;
+        }
         if (!getCommon().isInitialized()) {
+          return false;
+        }
+        if (!getTripInfo().isInitialized()) {
           return false;
         }
         return true;
@@ -2520,17 +3943,65 @@ public final class PubtransTableProtos {
       }
       private int bitField0_;
 
+      private int schemaVersion_ = 1;
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public boolean hasSchemaVersion() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public int getSchemaVersion() {
+        return schemaVersion_;
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public Builder setSchemaVersion(int value) {
+        bitField0_ |= 0x00000001;
+        schemaVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public Builder clearSchemaVersion() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        schemaVersion_ = 1;
+        onChanged();
+        return this;
+      }
+
       private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common, fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder> commonBuilder_;
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public boolean hasCommon() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon() {
         if (commonBuilder_ == null) {
@@ -2540,7 +4011,7 @@ public final class PubtransTableProtos {
         }
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder setCommon(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common value) {
         if (commonBuilder_ == null) {
@@ -2552,11 +4023,11 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder setCommon(
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder builderForValue) {
@@ -2566,15 +4037,15 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder mergeCommon(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common value) {
         if (commonBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
               common_ != null &&
               common_ != fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance()) {
             common_ =
@@ -2586,11 +4057,11 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder clearCommon() {
         if (commonBuilder_ == null) {
@@ -2599,19 +4070,19 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder getCommonBuilder() {
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         onChanged();
         return getCommonFieldBuilder().getBuilder();
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder() {
         if (commonBuilder_ != null) {
@@ -2622,7 +4093,7 @@ public final class PubtransTableProtos {
         }
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common, fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder> 
@@ -2636,6 +4107,124 @@ public final class PubtransTableProtos {
           common_ = null;
         }
         return commonBuilder_;
+      }
+
+      private fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo tripInfo_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder> tripInfoBuilder_;
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public boolean hasTripInfo() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo() {
+        if (tripInfoBuilder_ == null) {
+          return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+        } else {
+          return tripInfoBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder setTripInfo(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo value) {
+        if (tripInfoBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          tripInfo_ = value;
+          onChanged();
+        } else {
+          tripInfoBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder setTripInfo(
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder builderForValue) {
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = builderForValue.build();
+          onChanged();
+        } else {
+          tripInfoBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder mergeTripInfo(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo value) {
+        if (tripInfoBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+              tripInfo_ != null &&
+              tripInfo_ != fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance()) {
+            tripInfo_ =
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.newBuilder(tripInfo_).mergeFrom(value).buildPartial();
+          } else {
+            tripInfo_ = value;
+          }
+          onChanged();
+        } else {
+          tripInfoBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder clearTripInfo() {
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = null;
+          onChanged();
+        } else {
+          tripInfoBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder getTripInfoBuilder() {
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return getTripInfoFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder() {
+        if (tripInfoBuilder_ != null) {
+          return tripInfoBuilder_.getMessageOrBuilder();
+        } else {
+          return tripInfo_ == null ?
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+        }
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder> 
+          getTripInfoFieldBuilder() {
+        if (tripInfoBuilder_ == null) {
+          tripInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder>(
+                  getTripInfo(),
+                  getParentForChildren(),
+                  isClean());
+          tripInfo_ = null;
+        }
+        return tripInfoBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -2695,42 +4284,72 @@ public final class PubtransTableProtos {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    boolean hasSchemaVersion();
+    /**
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    int getSchemaVersion();
+
+    /**
+     * <code>required .proto.Common common = 2;</code>
      */
     boolean hasCommon();
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon();
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder();
 
     /**
-     * <code>optional int64 has_destination_display_id = 2;</code>
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    boolean hasTripInfo();
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo();
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder();
+
+    /**
+     * <code>optional int64 has_destination_display_id = 4;</code>
      */
     boolean hasHasDestinationDisplayId();
     /**
-     * <code>optional int64 has_destination_display_id = 2;</code>
+     * <code>optional int64 has_destination_display_id = 4;</code>
      */
     long getHasDestinationDisplayId();
 
     /**
-     * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+     * <code>optional int64 has_destination_stop_area_gid = 5;</code>
      */
     boolean hasHasDestinationStopAreaGid();
     /**
-     * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+     * <code>optional int64 has_destination_stop_area_gid = 5;</code>
      */
     long getHasDestinationStopAreaGid();
 
     /**
-     * <code>optional int64 has_service_requirement_id = 4;</code>
+     * <code>optional int64 has_service_requirement_id = 6;</code>
      */
     boolean hasHasServiceRequirementId();
     /**
-     * <code>optional int64 has_service_requirement_id = 4;</code>
+     * <code>optional int64 has_service_requirement_id = 6;</code>
      */
     long getHasServiceRequirementId();
   }
@@ -2747,6 +4366,7 @@ public final class PubtransTableProtos {
       super(builder);
     }
     private ROIDeparture() {
+      schemaVersion_ = 1;
       hasDestinationDisplayId_ = 0L;
       hasDestinationStopAreaGid_ = 0L;
       hasServiceRequirementId_ = 0L;
@@ -2776,9 +4396,14 @@ public final class PubtransTableProtos {
             case 0:
               done = true;
               break;
-            case 10: {
+            case 8: {
+              bitField0_ |= 0x00000001;
+              schemaVersion_ = input.readInt32();
+              break;
+            }
+            case 18: {
               fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = common_.toBuilder();
               }
               common_ = input.readMessage(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.PARSER, extensionRegistry);
@@ -2786,21 +4411,34 @@ public final class PubtransTableProtos {
                 subBuilder.mergeFrom(common_);
                 common_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00000001;
-              break;
-            }
-            case 16: {
               bitField0_ |= 0x00000002;
-              hasDestinationDisplayId_ = input.readInt64();
               break;
             }
-            case 24: {
+            case 26: {
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                subBuilder = tripInfo_.toBuilder();
+              }
+              tripInfo_ = input.readMessage(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(tripInfo_);
+                tripInfo_ = subBuilder.buildPartial();
+              }
               bitField0_ |= 0x00000004;
-              hasDestinationStopAreaGid_ = input.readInt64();
               break;
             }
             case 32: {
               bitField0_ |= 0x00000008;
+              hasDestinationDisplayId_ = input.readInt64();
+              break;
+            }
+            case 40: {
+              bitField0_ |= 0x00000010;
+              hasDestinationStopAreaGid_ = input.readInt64();
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
               hasServiceRequirementId_ = input.readInt64();
               break;
             }
@@ -2837,67 +4475,111 @@ public final class PubtransTableProtos {
     }
 
     private int bitField0_;
-    public static final int COMMON_FIELD_NUMBER = 1;
-    private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_;
+    public static final int SCHEMA_VERSION_FIELD_NUMBER = 1;
+    private int schemaVersion_;
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
      */
-    public boolean hasCommon() {
+    public boolean hasSchemaVersion() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <pre>
+     * Remember to bump up the version when updating the scema!
+     * </pre>
+     *
+     * <code>required int32 schema_version = 1 [default = 1];</code>
+     */
+    public int getSchemaVersion() {
+      return schemaVersion_;
+    }
+
+    public static final int COMMON_FIELD_NUMBER = 2;
+    private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_;
+    /**
+     * <code>required .proto.Common common = 2;</code>
+     */
+    public boolean hasCommon() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required .proto.Common common = 2;</code>
      */
     public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon() {
       return common_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance() : common_;
     }
     /**
-     * <code>required .proto.Common common = 1;</code>
+     * <code>required .proto.Common common = 2;</code>
      */
     public fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder() {
       return common_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance() : common_;
     }
 
-    public static final int HAS_DESTINATION_DISPLAY_ID_FIELD_NUMBER = 2;
-    private long hasDestinationDisplayId_;
+    public static final int TRIP_INFO_FIELD_NUMBER = 3;
+    private fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo tripInfo_;
     /**
-     * <code>optional int64 has_destination_display_id = 2;</code>
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
      */
-    public boolean hasHasDestinationDisplayId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+    public boolean hasTripInfo() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional int64 has_destination_display_id = 2;</code>
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo() {
+      return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+    }
+    /**
+     * <code>required .proto.DOITripInfo trip_info = 3;</code>
+     */
+    public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder() {
+      return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+    }
+
+    public static final int HAS_DESTINATION_DISPLAY_ID_FIELD_NUMBER = 4;
+    private long hasDestinationDisplayId_;
+    /**
+     * <code>optional int64 has_destination_display_id = 4;</code>
+     */
+    public boolean hasHasDestinationDisplayId() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional int64 has_destination_display_id = 4;</code>
      */
     public long getHasDestinationDisplayId() {
       return hasDestinationDisplayId_;
     }
 
-    public static final int HAS_DESTINATION_STOP_AREA_GID_FIELD_NUMBER = 3;
+    public static final int HAS_DESTINATION_STOP_AREA_GID_FIELD_NUMBER = 5;
     private long hasDestinationStopAreaGid_;
     /**
-     * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+     * <code>optional int64 has_destination_stop_area_gid = 5;</code>
      */
     public boolean hasHasDestinationStopAreaGid() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
-     * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+     * <code>optional int64 has_destination_stop_area_gid = 5;</code>
      */
     public long getHasDestinationStopAreaGid() {
       return hasDestinationStopAreaGid_;
     }
 
-    public static final int HAS_SERVICE_REQUIREMENT_ID_FIELD_NUMBER = 4;
+    public static final int HAS_SERVICE_REQUIREMENT_ID_FIELD_NUMBER = 6;
     private long hasServiceRequirementId_;
     /**
-     * <code>optional int64 has_service_requirement_id = 4;</code>
+     * <code>optional int64 has_service_requirement_id = 6;</code>
      */
     public boolean hasHasServiceRequirementId() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
-     * <code>optional int64 has_service_requirement_id = 4;</code>
+     * <code>optional int64 has_service_requirement_id = 6;</code>
      */
     public long getHasServiceRequirementId() {
       return hasServiceRequirementId_;
@@ -2910,11 +4592,23 @@ public final class PubtransTableProtos {
       if (isInitialized == 1) return true;
       if (isInitialized == 0) return false;
 
+      if (!hasSchemaVersion()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
       if (!hasCommon()) {
         memoizedIsInitialized = 0;
         return false;
       }
+      if (!hasTripInfo()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
       if (!getCommon().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getTripInfo().isInitialized()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -2926,16 +4620,22 @@ public final class PubtransTableProtos {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeMessage(1, getCommon());
+        output.writeInt32(1, schemaVersion_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeInt64(2, hasDestinationDisplayId_);
+        output.writeMessage(2, getCommon());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt64(3, hasDestinationStopAreaGid_);
+        output.writeMessage(3, getTripInfo());
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeInt64(4, hasServiceRequirementId_);
+        output.writeInt64(4, hasDestinationDisplayId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeInt64(5, hasDestinationStopAreaGid_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeInt64(6, hasServiceRequirementId_);
       }
       unknownFields.writeTo(output);
     }
@@ -2948,19 +4648,27 @@ public final class PubtransTableProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getCommon());
+          .computeInt32Size(1, schemaVersion_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(2, hasDestinationDisplayId_);
+          .computeMessageSize(2, getCommon());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(3, hasDestinationStopAreaGid_);
+          .computeMessageSize(3, getTripInfo());
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(4, hasServiceRequirementId_);
+          .computeInt64Size(4, hasDestinationDisplayId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(5, hasDestinationStopAreaGid_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(6, hasServiceRequirementId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2978,10 +4686,20 @@ public final class PubtransTableProtos {
       fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIDeparture other = (fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIDeparture) obj;
 
       boolean result = true;
+      result = result && (hasSchemaVersion() == other.hasSchemaVersion());
+      if (hasSchemaVersion()) {
+        result = result && (getSchemaVersion()
+            == other.getSchemaVersion());
+      }
       result = result && (hasCommon() == other.hasCommon());
       if (hasCommon()) {
         result = result && getCommon()
             .equals(other.getCommon());
+      }
+      result = result && (hasTripInfo() == other.hasTripInfo());
+      if (hasTripInfo()) {
+        result = result && getTripInfo()
+            .equals(other.getTripInfo());
       }
       result = result && (hasHasDestinationDisplayId() == other.hasHasDestinationDisplayId());
       if (hasHasDestinationDisplayId()) {
@@ -3009,9 +4727,17 @@ public final class PubtransTableProtos {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasSchemaVersion()) {
+        hash = (37 * hash) + SCHEMA_VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getSchemaVersion();
+      }
       if (hasCommon()) {
         hash = (37 * hash) + COMMON_FIELD_NUMBER;
         hash = (53 * hash) + getCommon().hashCode();
+      }
+      if (hasTripInfo()) {
+        hash = (37 * hash) + TRIP_INFO_FIELD_NUMBER;
+        hash = (53 * hash) + getTripInfo().hashCode();
       }
       if (hasHasDestinationDisplayId()) {
         hash = (37 * hash) + HAS_DESTINATION_DISPLAY_ID_FIELD_NUMBER;
@@ -3157,23 +4883,32 @@ public final class PubtransTableProtos {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
           getCommonFieldBuilder();
+          getTripInfoFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        schemaVersion_ = 1;
+        bitField0_ = (bitField0_ & ~0x00000001);
         if (commonBuilder_ == null) {
           common_ = null;
         } else {
           commonBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000001);
-        hasDestinationDisplayId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
-        hasDestinationStopAreaGid_ = 0L;
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = null;
+        } else {
+          tripInfoBuilder_.clear();
+        }
         bitField0_ = (bitField0_ & ~0x00000004);
-        hasServiceRequirementId_ = 0L;
+        hasDestinationDisplayId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000008);
+        hasDestinationStopAreaGid_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000010);
+        hasServiceRequirementId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -3205,21 +4940,33 @@ public final class PubtransTableProtos {
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
           to_bitField0_ |= 0x00000001;
         }
+        result.schemaVersion_ = schemaVersion_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
         if (commonBuilder_ == null) {
           result.common_ = common_;
         } else {
           result.common_ = commonBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.hasDestinationDisplayId_ = hasDestinationDisplayId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
         }
-        result.hasDestinationStopAreaGid_ = hasDestinationStopAreaGid_;
+        if (tripInfoBuilder_ == null) {
+          result.tripInfo_ = tripInfo_;
+        } else {
+          result.tripInfo_ = tripInfoBuilder_.build();
+        }
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
           to_bitField0_ |= 0x00000008;
+        }
+        result.hasDestinationDisplayId_ = hasDestinationDisplayId_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.hasDestinationStopAreaGid_ = hasDestinationStopAreaGid_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
         }
         result.hasServiceRequirementId_ = hasServiceRequirementId_;
         result.bitField0_ = to_bitField0_;
@@ -3271,8 +5018,14 @@ public final class PubtransTableProtos {
 
       public Builder mergeFrom(fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIDeparture other) {
         if (other == fi.hsl.common.transitdata.proto.PubtransTableProtos.ROIDeparture.getDefaultInstance()) return this;
+        if (other.hasSchemaVersion()) {
+          setSchemaVersion(other.getSchemaVersion());
+        }
         if (other.hasCommon()) {
           mergeCommon(other.getCommon());
+        }
+        if (other.hasTripInfo()) {
+          mergeTripInfo(other.getTripInfo());
         }
         if (other.hasHasDestinationDisplayId()) {
           setHasDestinationDisplayId(other.getHasDestinationDisplayId());
@@ -3290,10 +5043,19 @@ public final class PubtransTableProtos {
 
       @java.lang.Override
       public final boolean isInitialized() {
+        if (!hasSchemaVersion()) {
+          return false;
+        }
         if (!hasCommon()) {
           return false;
         }
+        if (!hasTripInfo()) {
+          return false;
+        }
         if (!getCommon().isInitialized()) {
+          return false;
+        }
+        if (!getTripInfo().isInitialized()) {
           return false;
         }
         return true;
@@ -3319,17 +5081,65 @@ public final class PubtransTableProtos {
       }
       private int bitField0_;
 
+      private int schemaVersion_ = 1;
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public boolean hasSchemaVersion() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public int getSchemaVersion() {
+        return schemaVersion_;
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public Builder setSchemaVersion(int value) {
+        bitField0_ |= 0x00000001;
+        schemaVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Remember to bump up the version when updating the scema!
+       * </pre>
+       *
+       * <code>required int32 schema_version = 1 [default = 1];</code>
+       */
+      public Builder clearSchemaVersion() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        schemaVersion_ = 1;
+        onChanged();
+        return this;
+      }
+
       private fi.hsl.common.transitdata.proto.PubtransTableProtos.Common common_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common, fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder> commonBuilder_;
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public boolean hasCommon() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common getCommon() {
         if (commonBuilder_ == null) {
@@ -3339,7 +5149,7 @@ public final class PubtransTableProtos {
         }
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder setCommon(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common value) {
         if (commonBuilder_ == null) {
@@ -3351,11 +5161,11 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder setCommon(
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder builderForValue) {
@@ -3365,15 +5175,15 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder mergeCommon(fi.hsl.common.transitdata.proto.PubtransTableProtos.Common value) {
         if (commonBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
               common_ != null &&
               common_ != fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.getDefaultInstance()) {
             common_ =
@@ -3385,11 +5195,11 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public Builder clearCommon() {
         if (commonBuilder_ == null) {
@@ -3398,19 +5208,19 @@ public final class PubtransTableProtos {
         } else {
           commonBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder getCommonBuilder() {
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
         onChanged();
         return getCommonFieldBuilder().getBuilder();
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       public fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder getCommonOrBuilder() {
         if (commonBuilder_ != null) {
@@ -3421,7 +5231,7 @@ public final class PubtransTableProtos {
         }
       }
       /**
-       * <code>required .proto.Common common = 1;</code>
+       * <code>required .proto.Common common = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           fi.hsl.common.transitdata.proto.PubtransTableProtos.Common, fi.hsl.common.transitdata.proto.PubtransTableProtos.Common.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.CommonOrBuilder> 
@@ -3437,33 +5247,151 @@ public final class PubtransTableProtos {
         return commonBuilder_;
       }
 
-      private long hasDestinationDisplayId_ ;
+      private fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo tripInfo_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder> tripInfoBuilder_;
       /**
-       * <code>optional int64 has_destination_display_id = 2;</code>
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
        */
-      public boolean hasHasDestinationDisplayId() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+      public boolean hasTripInfo() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
-       * <code>optional int64 has_destination_display_id = 2;</code>
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo getTripInfo() {
+        if (tripInfoBuilder_ == null) {
+          return tripInfo_ == null ? fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+        } else {
+          return tripInfoBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder setTripInfo(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo value) {
+        if (tripInfoBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          tripInfo_ = value;
+          onChanged();
+        } else {
+          tripInfoBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder setTripInfo(
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder builderForValue) {
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = builderForValue.build();
+          onChanged();
+        } else {
+          tripInfoBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder mergeTripInfo(fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo value) {
+        if (tripInfoBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+              tripInfo_ != null &&
+              tripInfo_ != fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance()) {
+            tripInfo_ =
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.newBuilder(tripInfo_).mergeFrom(value).buildPartial();
+          } else {
+            tripInfo_ = value;
+          }
+          onChanged();
+        } else {
+          tripInfoBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public Builder clearTripInfo() {
+        if (tripInfoBuilder_ == null) {
+          tripInfo_ = null;
+          onChanged();
+        } else {
+          tripInfoBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder getTripInfoBuilder() {
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return getTripInfoFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      public fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder getTripInfoOrBuilder() {
+        if (tripInfoBuilder_ != null) {
+          return tripInfoBuilder_.getMessageOrBuilder();
+        } else {
+          return tripInfo_ == null ?
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.getDefaultInstance() : tripInfo_;
+        }
+      }
+      /**
+       * <code>required .proto.DOITripInfo trip_info = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder> 
+          getTripInfoFieldBuilder() {
+        if (tripInfoBuilder_ == null) {
+          tripInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfo.Builder, fi.hsl.common.transitdata.proto.PubtransTableProtos.DOITripInfoOrBuilder>(
+                  getTripInfo(),
+                  getParentForChildren(),
+                  isClean());
+          tripInfo_ = null;
+        }
+        return tripInfoBuilder_;
+      }
+
+      private long hasDestinationDisplayId_ ;
+      /**
+       * <code>optional int64 has_destination_display_id = 4;</code>
+       */
+      public boolean hasHasDestinationDisplayId() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional int64 has_destination_display_id = 4;</code>
        */
       public long getHasDestinationDisplayId() {
         return hasDestinationDisplayId_;
       }
       /**
-       * <code>optional int64 has_destination_display_id = 2;</code>
+       * <code>optional int64 has_destination_display_id = 4;</code>
        */
       public Builder setHasDestinationDisplayId(long value) {
-        bitField0_ |= 0x00000002;
+        bitField0_ |= 0x00000008;
         hasDestinationDisplayId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int64 has_destination_display_id = 2;</code>
+       * <code>optional int64 has_destination_display_id = 4;</code>
        */
       public Builder clearHasDestinationDisplayId() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000008);
         hasDestinationDisplayId_ = 0L;
         onChanged();
         return this;
@@ -3471,31 +5399,31 @@ public final class PubtransTableProtos {
 
       private long hasDestinationStopAreaGid_ ;
       /**
-       * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+       * <code>optional int64 has_destination_stop_area_gid = 5;</code>
        */
       public boolean hasHasDestinationStopAreaGid() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
-       * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+       * <code>optional int64 has_destination_stop_area_gid = 5;</code>
        */
       public long getHasDestinationStopAreaGid() {
         return hasDestinationStopAreaGid_;
       }
       /**
-       * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+       * <code>optional int64 has_destination_stop_area_gid = 5;</code>
        */
       public Builder setHasDestinationStopAreaGid(long value) {
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000010;
         hasDestinationStopAreaGid_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int64 has_destination_stop_area_gid = 3;</code>
+       * <code>optional int64 has_destination_stop_area_gid = 5;</code>
        */
       public Builder clearHasDestinationStopAreaGid() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000010);
         hasDestinationStopAreaGid_ = 0L;
         onChanged();
         return this;
@@ -3503,31 +5431,31 @@ public final class PubtransTableProtos {
 
       private long hasServiceRequirementId_ ;
       /**
-       * <code>optional int64 has_service_requirement_id = 4;</code>
+       * <code>optional int64 has_service_requirement_id = 6;</code>
        */
       public boolean hasHasServiceRequirementId() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
-       * <code>optional int64 has_service_requirement_id = 4;</code>
+       * <code>optional int64 has_service_requirement_id = 6;</code>
        */
       public long getHasServiceRequirementId() {
         return hasServiceRequirementId_;
       }
       /**
-       * <code>optional int64 has_service_requirement_id = 4;</code>
+       * <code>optional int64 has_service_requirement_id = 6;</code>
        */
       public Builder setHasServiceRequirementId(long value) {
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000020;
         hasServiceRequirementId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int64 has_service_requirement_id = 4;</code>
+       * <code>optional int64 has_service_requirement_id = 6;</code>
        */
       public Builder clearHasServiceRequirementId() {
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000020);
         hasServiceRequirementId_ = 0L;
         onChanged();
         return this;
@@ -3591,6 +5519,11 @@ public final class PubtransTableProtos {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_proto_Common_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_proto_DOITripInfo_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_proto_DOITripInfo_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_proto_ROIArrival_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -3624,14 +5557,20 @@ public final class PubtransTableProtos {
       "_date_time_ms\030\014 \001(\003\022!\n\031observed_utc_date" +
       "_time_ms\030\r \001(\003\022\r\n\005state\030\016 \002(\003\022\014\n\004type\030\017 " +
       "\002(\003\022\027\n\017is_valid_yes_no\030\020 \002(\010\022&\n\036last_mod" +
-      "ified_utc_date_time_ms\030\021 \002(\003\"+\n\nROIArriv" +
-      "al\022\035\n\006common\030\001 \002(\0132\r.proto.Common\"\234\001\n\014RO" +
-      "IDeparture\022\035\n\006common\030\001 \002(\0132\r.proto.Commo" +
-      "n\022\"\n\032has_destination_display_id\030\002 \001(\003\022%\n" +
-      "\035has_destination_stop_area_gid\030\003 \001(\003\022\"\n\032" +
-      "has_service_requirement_id\030\004 \001(\003B6\n\037fi.h" +
-      "sl.common.transitdata.protoB\023PubtransTab" +
-      "leProtos"
+      "ified_utc_date_time_ms\030\021 \002(\003\"\201\001\n\013DOITrip" +
+      "Info\022\016\n\006dvj_id\030\001 \002(\003\022\025\n\roperating_day\030\002 " +
+      "\002(\t\022\020\n\010route_id\030\003 \002(\t\022\024\n\014direction_id\030\004 " +
+      "\002(\r\022\022\n\nstart_time\030\005 \002(\t\022\017\n\007stop_id\030\006 \002(\003" +
+      "\"m\n\nROIArrival\022\031\n\016schema_version\030\001 \002(\005:\001" +
+      "1\022\035\n\006common\030\002 \002(\0132\r.proto.Common\022%\n\ttrip" +
+      "_info\030\003 \002(\0132\022.proto.DOITripInfo\"\336\001\n\014ROID" +
+      "eparture\022\031\n\016schema_version\030\001 \002(\005:\0011\022\035\n\006c" +
+      "ommon\030\002 \002(\0132\r.proto.Common\022%\n\ttrip_info\030" +
+      "\003 \002(\0132\022.proto.DOITripInfo\022\"\n\032has_destina" +
+      "tion_display_id\030\004 \001(\003\022%\n\035has_destination" +
+      "_stop_area_gid\030\005 \001(\003\022\"\n\032has_service_requ" +
+      "irement_id\030\006 \001(\003B6\n\037fi.hsl.common.transi" +
+      "tdata.protoB\023PubtransTableProtos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -3651,18 +5590,24 @@ public final class PubtransTableProtos {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_proto_Common_descriptor,
         new java.lang.String[] { "SchemaVersion", "Id", "IsOnDatedVehicleJourneyId", "IsOnMonitoredVehicleJourneyId", "JourneyPatternSequenceNumber", "IsTimetabledAtJourneyPatternPointGid", "VisitCountNumber", "IsTargetedAtJourneyPatternPointGid", "WasObservedAtJourneyPatternPointGid", "TimetabledLatestUtcDateTimeMs", "TargetUtcDateTimeMs", "EstimatedUtcDateTimeMs", "ObservedUtcDateTimeMs", "State", "Type", "IsValidYesNo", "LastModifiedUtcDateTimeMs", });
-    internal_static_proto_ROIArrival_descriptor =
+    internal_static_proto_DOITripInfo_descriptor =
       getDescriptor().getMessageTypes().get(1);
+    internal_static_proto_DOITripInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_proto_DOITripInfo_descriptor,
+        new java.lang.String[] { "DvjId", "OperatingDay", "RouteId", "DirectionId", "StartTime", "StopId", });
+    internal_static_proto_ROIArrival_descriptor =
+      getDescriptor().getMessageTypes().get(2);
     internal_static_proto_ROIArrival_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_proto_ROIArrival_descriptor,
-        new java.lang.String[] { "Common", });
+        new java.lang.String[] { "SchemaVersion", "Common", "TripInfo", });
     internal_static_proto_ROIDeparture_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(3);
     internal_static_proto_ROIDeparture_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_proto_ROIDeparture_descriptor,
-        new java.lang.String[] { "Common", "HasDestinationDisplayId", "HasDestinationStopAreaGid", "HasServiceRequirementId", });
+        new java.lang.String[] { "SchemaVersion", "Common", "TripInfo", "HasDestinationDisplayId", "HasDestinationStopAreaGid", "HasServiceRequirementId", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)


### PR DESCRIPTION
This is a breaking change for clients updating to this version!!

create schema for DOITripInfo which allows us to remove DOI data (read from DOI and put to Redis in the pipeline)  from Pulsar properties and put to payload. improves our schemas and removes unnecessary application specific internal datamodels (TripUpdateProcessor). Also allows us to create TripEstimates.

part of this larger refactoring: 
https://github.com/HSLdevcom/transitdata-tripupdate-processor/issues/40