### PR TITLE
feat/integration-test-noop-message-handler

### DIFF
--- a/src/integration-test/java/fi/hsl/common/pulsar/ITCursorResetToLatestTest.java
+++ b/src/integration-test/java/fi/hsl/common/pulsar/ITCursorResetToLatestTest.java
@@ -1,8 +1,6 @@
 package fi.hsl.common.pulsar;
 
 import com.typesafe.config.Config;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.junit.Test;
@@ -113,26 +111,4 @@ public class ITCursorResetToLatestTest extends ITBaseTestSuite {
         TestPipeline.MultiMessageTestLogic logic = new TestPipeline.MultiMessageTestLogic(input, output);
         testPulsarMessageHandler(handler, app, logic, testId);
     }
-
-    // message handler which just passes messages unmodified
-    public class NoopMessageHandler implements IMessageHandler {
-        private Consumer<byte[]> consumer;
-        private Producer<byte[]> producer;
-
-        public NoopMessageHandler(PulsarApplicationContext context) {
-            consumer = context.getConsumer();
-            producer = context.getProducer();
-        }
-
-        public void handleMessage(Message received) throws Exception {
-            consumer.acknowledgeAsync(received);
-            producer.newMessage()
-                    .key(received.getKey())
-                    .eventTime(received.getEventTime())
-                    .properties(received.getProperties())
-                    .value(received.getData())
-                    .sendAsync();
-        }
-    }
-
 }

--- a/src/integration-test/java/fi/hsl/common/pulsar/NoopMessageHandler.java
+++ b/src/integration-test/java/fi/hsl/common/pulsar/NoopMessageHandler.java
@@ -1,0 +1,28 @@
+package fi.hsl.common.pulsar;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+
+/**
+ *  Message handler which just passes messages unmodified
+ */
+public class NoopMessageHandler implements IMessageHandler {
+    private Consumer<byte[]> consumer;
+    private Producer<byte[]> producer;
+
+    public NoopMessageHandler(PulsarApplicationContext context) {
+        consumer = context.getConsumer();
+        producer = context.getProducer();
+    }
+
+    public void handleMessage(Message received) throws Exception {
+        consumer.acknowledgeAsync(received);
+        producer.newMessage()
+                .key(received.getKey())
+                .eventTime(received.getEventTime())
+                .properties(received.getProperties())
+                .value(received.getData())
+                .sendAsync();
+    }
+}


### PR DESCRIPTION
 - Take NoopMessageHandler out of ITCursorResetToLatestTest so that it can be reused