### PR TITLE
Add support for setting ackTimeout for Pulsar subscription

### DIFF
--- a/src/main/java/fi/hsl/common/pulsar/PulsarApplication.java
+++ b/src/main/java/fi/hsl/common/pulsar/PulsarApplication.java
@@ -160,6 +160,12 @@ public class PulsarApplication implements AutoCloseable {
             builder = builder.topic(topic);
         }
 
+        if (config.hasPath("pulsar.consumer.ackTimeoutSecs")) {
+            long ackTimeOutSecs = config.getLong("pulsar.consumer.ackTimeoutSecs");
+            log.info("Setting message redelivery (ackTimeout) time to {} s in pulsar consumer subscription", ackTimeOutSecs);
+            builder = builder.ackTimeout(ackTimeOutSecs, TimeUnit.SECONDS);
+        }
+
         Consumer<byte[]> consumer = builder.subscribe();
 
         if (config.getBoolean("pulsar.consumer.cursor.resetToLatest")) {


### PR DESCRIPTION
This is needed in e.g. transitlog-sink - downtime of the sink results to large Pulsar backlog of unacknowledged messages that need to be read again. This config adds support for automatic redelivery of these messages. 