### PR TITLE
Build: Keep some older versions

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           package-type: 'maven'
           package-name: 'fi.hsl.transitdata-common'
-          min-versions-to-keep: 5
+          min-versions-to-keep: 50


### PR DESCRIPTION
We have been missing old versions of this package. We could remove this removal entirely as we seem to be using a public package repository with no storage limit. However, it might be nicer for the world to clean up a bit.

Setting the limit to 50 probably does not harm us. As we systematically will start using Dependabot, we should not need old versions anymore.
